### PR TITLE
Fix VERSION extraction

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ my $year = (localtime)[5] + 1900;
 
 # Slurp the program source and dig out the version number.
 my $text = do { local ( @ARGV, $/ ) = $path; <> };
-my $version = $2 if ( $text =~ /^(my|our) \$VERSION\s*=\s*'?(.*)'?/m );
+my $version = $2 if ( $text =~ /^(my|our) \$VERSION\s*=\s*'?([^;]*)'?/m );
 
 WriteMakefile(
     NAME      => 'Gtk3::ImageView',


### PR DESCRIPTION
Makefile.PL extracts VERSION value from lib/Gtk3/ImageView.pm
including the traling semicolon. ExtUtils::MM_Any then complains:

$ perl Makefile.PL
Version string '4;' contains invalid data; ignoring: ';' at /usr/share/perl5/vendor_perl/ExtUtils/MM_Any.pm line 2286.
Generating a Unix-style Makefile
Writing Makefile for Gtk3::ImageView
Writing MYMETA.yml and MYMETA.json

This patch fixes it.